### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Contabo Server
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/shabeer05in/Sag/security/code-scanning/1](https://github.com/shabeer05in/Sag/security/code-scanning/1)

To fix this problem, you should explicitly set the `permissions` block in your workflow file. The best way to do this is to add a minimal permissions block either at the root (applies to all jobs) or within the specific job if you have jobs with different requirements. For your `deploy` job, since it interacts with the server only by SSH and does not need to read or write anything from the repo via the `GITHUB_TOKEN`, you can set the most restrictive permissions: `contents: read`. This will ensure the token cannot perform any write actions. The change should be made in `.github/workflows/deploy.yml`, ideally as a root-level block just below `name:` and above `on:` (applies to all jobs). No new methods, imports, or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
